### PR TITLE
fix: add InsufficientBalance and ProposalExpired error variants

### DIFF
--- a/contracts/contracts/treasury/src/errors.rs
+++ b/contracts/contracts/treasury/src/errors.rs
@@ -28,4 +28,8 @@ pub enum TreasuryError {
     AlreadyApproved = 10,
     /// The address is already registered as a signer.
     AlreadyASigner = 11,
+    /// The balance is insufficient for the requested operation.
+    InsufficientBalance = 12,
+    /// The proposal has expired and can no longer be executed.
+    ProposalExpired = 13,
 }

--- a/contracts/contracts/treasury/src/lib.rs
+++ b/contracts/contracts/treasury/src/lib.rs
@@ -369,4 +369,29 @@ impl TreasuryContract {
     }
 }
 
+/// Helper function to require that the contract has been initialized.
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+///
+/// # Returns
+/// * `Ok(())` if the contract is initialized
+/// * `Err(TreasuryError::NotInitialized)` if not initialized
+///
+/// # Usage
+/// Call this at the start of any function that requires the contract to be initialized:
+/// ```rust
+/// fn some_function(env: Env, ...) {
+///     require_initialized(&env)?;
+///     // ... rest of function
+/// }
+/// ```
+pub fn require_initialized(env: &Env) -> Result<(), TreasuryError> {
+    if !has_admin(env) {
+        Err(TreasuryError::NotInitialized)
+    } else {
+        Ok(())
+    }
+}
+
 mod test;


### PR DESCRIPTION
## Summary
Adds new error constants and a helper function to the Treasury contract as requested in issue #1.

## Changes Made

### errors.rs
- Added `InsufficientBalance` error variant (u12)
- Added `ProposalExpired` error variant (u13)

### lib.rs
- Added `require_initialized(env)` helper function to reduce boilerplate
- Function returns `Result<(), TreasuryError>`
- Includes comprehensive doc comments with usage example

## Acceptance Criteria
- [x] Added InsufficientBalance error variant (u12)
- [x] Added ProposalExpired error variant (u13)
- [x] Added require_initialized(env) helper function
- [x] Doc comments for each error explaining when it's triggered

## Notes
Cargo not available locally to test build, but changes follow existing patterns in the codebase.