### PR TITLE
feat(ci): add GitHub Actions CI/CD pipeline and README badges

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,60 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend.yml'
+
+jobs:
+  lint:
+    name: Lint (npm run lint)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+  build:
+    name: Build (npm run build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,75 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'contracts/**'
+      - '.github/workflows/rust.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'contracts/**'
+      - '.github/workflows/rust.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test (cargo test --all)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contracts/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('contracts/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run all tests
+        run: cargo test --all
+
+  build:
+    name: Release build (cargo build --release --all)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contracts/target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('contracts/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-
+
+      - name: Build release
+        run: cargo build --release --all

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # OrbitPay
 
+[![Rust CI](https://github.com/xqcxx/OrbitPay/actions/workflows/rust.yml/badge.svg)](https://github.com/xqcxx/OrbitPay/actions/workflows/rust.yml)
+[![Frontend CI](https://github.com/xqcxx/OrbitPay/actions/workflows/frontend.yml/badge.svg)](https://github.com/xqcxx/OrbitPay/actions/workflows/frontend.yml)
+[![Docs](https://github.com/xqcxx/OrbitPay/actions/workflows/docs.yml/badge.svg)](https://github.com/xqcxx/OrbitPay/actions/workflows/docs.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 Decentralized Payroll, Vesting & Treasury Protocol on Stellar Soroban.
 
 ```


### PR DESCRIPTION
## Summary

Sets up automated GitHub Actions workflows for both the Rust contracts and the Next.js frontend, and adds status badges to the README.

### `.github/workflows/rust.yml`

Two parallel jobs, path-filtered to `contracts/**`:

| Job | Command | Purpose |
|-----|---------|---------|
| `test` | `cargo test --all` | Runs on every PR/push to `main` |
| `build` | `cargo build --release --all` | Verifies release compilation |

Both use `dtolnay/rust-toolchain@stable` with `wasm32-unknown-unknown` and a shared Cargo registry cache.

### `.github/workflows/frontend.yml`

Two parallel jobs, path-filtered to `frontend/**`:

| Job | Command | Purpose |
|-----|---------|---------|
| `lint` | `npm run lint` | Lints on every PR/push to `main` |
| `build` | `npm run build` | Build verification |

Both use Node.js 20 with npm cache keyed on `frontend/package-lock.json`.

### README badges

Added below the title:
- `Rust CI` — links to `rust.yml` workflow runs
- `Frontend CI` — links to `frontend.yml` workflow runs
- `Docs` — links to `docs.yml` workflow runs (added by #71)
- `License: MIT`

Closes #70